### PR TITLE
Allow specifying 0 padding for mode-line, header-line, etc.

### DIFF
--- a/spacious-padding.el
+++ b/spacious-padding.el
@@ -241,15 +241,18 @@ overline."
     (let* ((original-bg (face-background face nil fallback))
            (subtle-bg (face-background 'default))
            (subtlep (and subtle-key spacious-padding-subtle-mode-line))
-           (bg (if subtlep subtle-bg original-bg)))
+           (bg (if subtlep subtle-bg original-bg))
+           (face-width (spacious-padding--get-face-width face)))
       `(,@(when subtlep
             (list
              :background bg
              :overline (spacious-padding--get-face-overline-color face fallback subtle-key)))
-        :box
-        ( :line-width ,(spacious-padding--get-face-width face)
-          :color ,bg
-          :style nil)))))
+        ,@(unless (eq face-width 0)
+            (list
+             :box
+             `( :line-width ,face-width
+                :color ,bg
+                :style nil)))))))
 
 (defun spacious-padding-set-window-divider (face color)
   "Set window divider FACE to COLOR its width is greater than 1."


### PR DESCRIPTION
Currently, attempting to set any key of `spacious-padding-widths` that uses `spacious-padding-set-face-box-padding` (eg. `:mode-line-width`, `:header-line-width`) in box width calculations to 0 results in an error similar to the following:
```
Error (use-package): spacious-padding/:config: Invalid face box: :line-width, 0, :color, "#24273a", :style, nil
```

This is because 0 is an invalid value for `:line-width` in a face's `:box`. This PR adds a check to see if the specified padding width is 0 before adding the box, and only adds the box if the width is not 0 (if the specified width is 0, then the box is unnecessary, since no padding needs to be added).