### PR TITLE
Draw the underline at the descent line

### DIFF
--- a/README.org
+++ b/README.org
@@ -209,9 +209,6 @@ which can be used as described above. [ These faces are the new names
 of the now-obsolete ~spacious-padding-subtle-mode-line-active~ and
 ~spacious-padding-subtle-mode-line-inactive~ as part of {{{development-version}}}. ]
 
-For optimal results with underlines, set ~x-underline-at-descent-line~
-to a non-nil value.
-
 * Installation
 :PROPERTIES:
 :CUSTOM_ID: h:f3bdac2c-4704-4a51-948c-a789a2589790
@@ -289,10 +286,6 @@ Everything is in place to set up the package.
 (setq spacious-padding-subtle-frame-lines
       `( :mode-line-active 'default
          :mode-line-inactive vertical-border))
-
-;; Make the underlines appear below the base line, to create a more
-;; consistent effect between overlines and underlines.
-(setq x-underline-at-descent-line t)
 
 (spacious-padding-mode 1)
 

--- a/spacious-padding.el
+++ b/spacious-padding.el
@@ -234,10 +234,7 @@ which can be used as described above.  Another example:
           \\='( :mode-line-active spacious-padding-line-active
              :mode-line-inactive spacious-padding-line-inactive
              :header-line-active spacious-padding-line-active
-             :header-line-inactive spacious-padding-line-inactive))
-
-For optimal results with underlines, set `x-underline-at-descent-line'
-to a non-nil value."
+             :header-line-inactive spacious-padding-line-inactive))"
   :type '(choice boolean
                  (plist
                   :key-type (choice (const :mode-line-active)
@@ -328,12 +325,14 @@ overline."
            (bg (if subtlep subtle-bg original-bg))
            (face-width (spacious-padding--get-face-width face)))
       `(,@(when subtlep
-            (flatten-list
-             (list
-              :background bg
+             (append
+              (list :background bg)
               (if (memq subtle-key '(:header-line-active :header-line-inactive))
-                  (list :underline (spacious-padding--get-face-line-color face fallback subtle-key))
-                (list :overline (spacious-padding--get-face-line-color face fallback subtle-key))))))
+                  (list :underline
+                    (list
+                     :color (spacious-padding--get-face-line-color face fallback subtle-key)
+                     :position t))
+                (list :overline (spacious-padding--get-face-line-color face fallback subtle-key)))))
         ,@(unless (eq face-width 0)
             (list
              :box


### PR DESCRIPTION
This patch configures the header-line's underline to be drawn at the descent line in the face itself instead of telling the user set `x-underline-at-descent-line` globally. I'm also happy to make this a user option, but I can't image anyone wanting to change it.

Motivation: I agree that drawing the header-line's underline at the descent line looks better, but I generally want underlines in text to be drawn where the font specifies.